### PR TITLE
Removed use of deprecated sfdisk options

### DIFF
--- a/common.sh.in
+++ b/common.sh.in
@@ -91,9 +91,10 @@ format_disk0() {
   # some versions of sfdisk need manual specification of 
   # head/sectors for devices such as drbd which don't 
   # report geometry
-  sfdisk -H 255 -S 63 --quiet --Linux "$1" <<EOF
-0,,L,*
+  sfdisk --quiet --force "$1" << EOF
+;
 EOF
+ 
 }
 
 map_disk0() {


### PR DESCRIPTION
I has having problems with a new ubuntu-15.10+ganeti 2.15 install.  Every time I tried it, sfdisk would bomb.  Found a bunch of other posts from others having the same problem.

Turns out the -H, -S flags are all deprecated and cause the bootstrap to fail.  Telling sfdisk to make one big partition should work on older sfdisk's as well.

This fix makes it work with my ubuntu-15.10 system.  The man page for the current sfdisk says:

```
--Linux
              Deprecated and ignored option.  Partitioning that is  compatible
              with Linux (and other modern OS) is the default.
```

So I removed that one as well.
